### PR TITLE
Add gitignore for generated outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+build/
+dist/
+*.egg-info/
+
+# Virtual environments
+.venv/
+.venv*/
+
+# Editor and OS cruft
+.DS_Store
+Thumbs.db
+
+# Logs and raw LLM payloads
+homedoc.log
+llm_raw.txt
+
+# CLI output directories
+out/
+results/
+translations/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+# Contributing
+
+Thanks for improving **homedoc-subtitle-translator**! To keep the project easy
+to review and ship, please follow these guidelines:
+
+1. Keep pull requests small, focused, and well-tested.
+2. Update documentation alongside behaviour changes.
+3. For releases:
+   - bump `__version__` in `setzer_cli.py` (or in the shared version module if we add one),
+   - update the changelog section in `README.md` if present,
+   - tag the release and push the tag after merging.
+
+Issues and PRs are welcome. Please keep discussions respectful and actionable.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,94 @@
-this is where the readme.md will live
+# homedoc-subtitle-translator
+
+Translate `.srt`, `.vtt`, and `.tsv` subtitle files with a local Ollama-compatible
+large language model. The project follows the homedoc toolkit style with a
+CLI-first workflow and an optional Tk GUI wrapper.
+
+## Run or Install
+
+```bash
+# install with pipx (recommended)
+pipx install .
+
+# or run from a local checkout
+pip install --user .
+
+# run without installing (from repo root)
+python setzer_cli.py --help
+```
+
+Quick examples:
+
+```bash
+# dry run (no LLM calls)
+setzer --in samples/demo.srt --out ./out --no-llm --flat
+
+# translate with explicit server/model and streaming enabled
+setzer \
+  --in samples/demo.srt \
+  --out ./out \
+  --server http://127.0.0.1:11434 \
+  --model gemma3:12b \
+  --stream
+
+# disable streaming
+setzer --in demo.vtt --out ./out --no-stream
+```
+
+See [USAGE.md](USAGE.md) for the full flag reference and examples.
+
+## Update setzer
+
+To upgrade an existing pipx installation, reinstall the package:
+
+```bash
+pipx reinstall homedoc-subtitle-translator
+```
+
+If you installed with `pip`, run:
+
+```bash
+pip install --user --upgrade homedoc-subtitle-translator
+```
+
+## Remove setzer
+
+Uninstall with the same tool you used originally:
+
+```bash
+# pipx install
+pipx uninstall homedoc-subtitle-translator
+
+# pip install
+pip uninstall homedoc-subtitle-translator
+```
+
+## Usage
+
+The CLI keeps homedoc-style defaults: environment variables provide fallback
+values for the LLM server, model, and streaming options. Run `setzer --help` to
+see all arguments, or the alias `homedoc-subtitle-translator` for the same
+behaviour.
+
+## Outputs
+
+Every CLI invocation writes:
+
+- `report.<ext>` — rewritten subtitle file matching the input format.
+- `homedoc.log` — timestamped log of the run.
+- `llm_raw.txt` — raw LLM payloads when streaming or `--debug` is active.
+
+By default results are placed in `--out/<YYYYMMDD-HHMMSS>/`. Use `--flat` to
+write directly into the specified output directory.
+
+## Notes & Safety
+
+- `--debug` logs raw LLM payloads into `llm_raw.txt`. Inspect before sharing
+  outputs beyond your local environment.
+- No network calls are made beyond the configured Ollama-compatible endpoint.
+- The optional `setzer-gui` command provides a thin Tk wrapper that calls the
+  same core translation routines.
+
+## License
+
+Distributed under the terms of the GPL-3.0-or-later license. See [LICENSE](LICENSE).

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,0 +1,89 @@
+# Usage
+
+`setzer` translates subtitle files with a homedoc-style CLI. All flags are
+available through the `homedoc-subtitle-translator` alias as well.
+
+## Flags
+
+| Flag | Type | Default | Env Var | Description |
+| --- | --- | --- | --- | --- |
+| `--in` | path | required | – | Input subtitle (`.srt`, `.vtt`, `.tsv`). |
+| `--out` | path | required | – | Output directory. |
+| `--flat` / `--no-flat` | bool | `--no-flat` | – | Write directly into `--out` or into a timestamped subfolder. |
+| `--source` | text | `auto` | – | Source language hint. |
+| `--target` | text | `English` | – | Target language. |
+| `--batch-per-chunk` | int | `1` | – | Number of cues per LLM request when chunking. |
+| `--max-chars` | int | `4000` | – | Planning size for chunk generation. |
+| `--no-translate-bracketed` | bool | disabled | – | Preserve bracketed tags such as `[MUSIC]`. |
+| `--server` | URL | `http://127.0.0.1:11434` | `HOMEDOC_LLM_SERVER` | Ollama-compatible server URL. |
+| `--model` | text | `gemma3:12b` | `HOMEDOC_LLM_MODEL` | Model identifier to request. |
+| `--llm-mode` | choice | `auto` | `HOMEDOC_LLM_MODE` | Prefer `chat`, `generate`, or auto-switching. |
+| `--stream` / `--no-stream` | bool | env / `True` | `HOMEDOC_STREAM` | Stream responses line-by-line. |
+| `--timeout` | float | `60` | `HOMEDOC_HTTP_TIMEOUT` | HTTP timeout in seconds. |
+| `--no-llm` | bool | disabled | – | Skip the LLM and reuse original text. |
+| `--debug` | bool | disabled | – | Verbose logging and raw payload capture. |
+| `--version` | flag | – | – | Print version and exit. |
+
+Environment variables provide defaults when the related flags are omitted. If
+`HOMEDOC_STREAM` is `0` or `false`, streaming is disabled unless `--stream` is
+explicitly provided. When `HOMEDOC_TZ` is set, folder mode uses that timezone
+for the `<YYYYMMDD-HHMMSS>` output name.
+
+## Examples
+
+### Minimal dry run
+
+```bash
+setzer --in demo.srt --out ./out --no-llm --flat
+```
+
+### Translate an SRT file (timestamped folder)
+
+```bash
+setzer --in drama.srt --out ./translated --server http://127.0.0.1:11434 --model gemma3:12b
+```
+
+### Flat output placement
+
+```bash
+setzer --in talk.vtt --out ./translated --flat
+```
+
+### Batch mode
+
+```bash
+setzer --in lessons.srt --out ./translated --batch-per-chunk 8 --max-chars 6000
+```
+
+### Preserve bracketed tags
+
+```bash
+setzer --in concert.srt --out ./translated --no-translate-bracketed
+```
+
+### LLM mode controls
+
+```bash
+setzer --in doc.vtt --out ./translated --llm-mode chat
+setzer --in doc.vtt --out ./translated --llm-mode generate
+```
+
+### Toggle streaming
+
+```bash
+setzer --in demo.tsv --out ./translated --stream
+setzer --in demo.tsv --out ./translated --no-stream
+```
+
+### Short timeout demo
+
+```bash
+setzer --in drama.srt --out ./translated --server http://127.0.0.1:65535 --timeout 1
+# -> Expect a timeout error and non-zero exit code.
+```
+
+## GUI Wrapper
+
+`setzer-gui` launches a minimal Tk application with the same core translation
+logic. Use the GUI to plan chunks, run full translations, or process a single
+chunk at a time. The `Abort` button stops queued work before the next LLM call.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "homedoc-subtitle-translator"
+version = "0.1.0"
+description = "Translate SRT/VTT/TSV via a local LLM (Ollama-compatible). CLI-first with optional Tk GUI. Stdlib-only."
+readme = "README.md"
+requires-python = ">=3.9"
+license = { text = "GPL-3.0-or-later" }
+authors = [{ name = "Martin Fellner", email = "martin.fellner@tmw.at" }]
+classifiers = [
+  "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
+  "Programming Language :: Python :: 3 :: Only",
+  "Environment :: Console",
+  "Topic :: Utilities",
+]
+
+[project.scripts]
+setzer = "setzer_cli:main"
+homedoc-subtitle-translator = "setzer_cli:main"
+setzer-gui = "setzer_gui:main"
+
+[tool.setuptools]
+py-modules = ["setzer_core", "setzer_cli", "setzer_gui"]

--- a/setzer_cli.py
+++ b/setzer_cli.py
@@ -1,0 +1,286 @@
+"""CLI entry point for homedoc-subtitle-translator."""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import os
+import sys
+from pathlib import Path
+from typing import Callable, List, Optional
+
+from setzer_core import (
+    Chunk,
+    Transcript,
+    build_output,
+    make_chunks,
+    read_transcript,
+    translate_range,
+)
+
+__version__ = "0.1.0"
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() not in {"0", "false", "no", "off"}
+
+
+def _env_value(name: str, default: str) -> str:
+    return os.getenv(name, default)
+
+
+class Logger:
+    def __init__(self, *, file_path: Optional[Path], verbose: bool) -> None:
+        self.file_path = file_path
+        self.verbose = verbose
+        self._handle = None
+        if file_path is not None:
+            try:
+                self._handle = file_path.open("a", encoding="utf-8")
+            except OSError:
+                self._handle = None
+
+    def log(self, message: str) -> None:
+        timestamp = dt.datetime.now().isoformat(timespec="seconds")
+        line = f"[{timestamp}] {message}"
+        print(line)
+        if self._handle is not None:
+            try:
+                self._handle.write(line + "\n")
+                self._handle.flush()
+            except OSError:
+                self._handle = None
+
+    def close(self) -> None:
+        if self._handle is not None:
+            try:
+                self._handle.close()
+            finally:
+                self._handle = None
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    server_default = _env_value("HOMEDOC_LLM_SERVER", "http://127.0.0.1:11434")
+    model_default = _env_value("HOMEDOC_LLM_MODEL", "gemma3:12b")
+    mode_default = _env_value("HOMEDOC_LLM_MODE", "auto")
+    stream_default = _env_bool("HOMEDOC_STREAM", True)
+    timeout_default = float(_env_value("HOMEDOC_HTTP_TIMEOUT", "60"))
+
+    parser = argparse.ArgumentParser(
+        description="Translate subtitle files using a local Ollama-compatible LLM.",
+    )
+    parser.add_argument("--in", dest="input_path", required=True, help="Input subtitle file (.srt/.vtt/.tsv)")
+    parser.add_argument("--out", dest="output_dir", required=True, help="Output directory for generated files")
+    parser.add_argument(
+        "--flat",
+        action="store_true",
+        default=False,
+        help="Write outputs directly into --out (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--no-flat",
+        dest="flat",
+        action="store_false",
+        help="Write into timestamped folder within --out (default)",
+    )
+    parser.add_argument("--source", default="auto", help="Source language (default: %(default)s)")
+    parser.add_argument("--target", default="English", help="Target language (default: %(default)s)")
+    parser.add_argument(
+        "--batch-per-chunk",
+        type=int,
+        default=1,
+        help="Number of cues to send per LLM request (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--max-chars",
+        type=int,
+        default=4000,
+        help="Maximum characters per chunk when planning (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--no-translate-bracketed",
+        dest="translate_bracketed",
+        action="store_false",
+        default=True,
+        help="Preserve bracketed tags like [MUSIC] without translation",
+    )
+    parser.add_argument(
+        "--server",
+        default=server_default,
+        help=f"LLM server URL (default: {server_default})",
+    )
+    parser.add_argument(
+        "--model",
+        default=model_default,
+        help=f"LLM model tag (default: {model_default})",
+    )
+    parser.add_argument(
+        "--llm-mode",
+        choices=["auto", "generate", "chat"],
+        default=mode_default,
+        help=f"LLM mode (default: {mode_default})",
+    )
+    stream_group = parser.add_mutually_exclusive_group()
+    stream_group.add_argument(
+        "--stream",
+        dest="stream",
+        action="store_true",
+        default=stream_default,
+        help="Enable streaming responses",
+    )
+    stream_group.add_argument(
+        "--no-stream",
+        dest="stream",
+        action="store_false",
+        help="Disable streaming responses",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=timeout_default,
+        help=f"HTTP timeout in seconds (default: {timeout_default})",
+    )
+    parser.add_argument(
+        "--no-llm",
+        action="store_true",
+        help="Skip LLM calls and reuse original text",
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Enable verbose logging and capture raw LLM responses",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
+    )
+    return parser
+
+
+def _resolve_output_directory(base: Path, flat: bool) -> Path:
+    if flat:
+        base.mkdir(parents=True, exist_ok=True)
+        return base
+    tz_name = os.getenv("HOMEDOC_TZ")
+    now = dt.datetime.now()
+    if tz_name:
+        try:
+            from zoneinfo import ZoneInfo
+
+            tz = ZoneInfo(tz_name)
+            now = dt.datetime.now(tz)
+        except Exception:
+            pass
+    folder_name = now.strftime("%Y%m%d-%H%M%S")
+    target = base / folder_name
+    target.mkdir(parents=True, exist_ok=True)
+    return target
+
+
+def _write_file(path: Path, content: str) -> None:
+    try:
+        path.write_text(content, encoding="utf-8")
+    except OSError as exc:
+        raise RuntimeError(f"Unable to write {path.name}: {exc}") from exc
+
+
+def _output_filename(fmt: str) -> str:
+    mapping = {"srt": "report.srt", "vtt": "report.vtt", "tsv": "report.tsv"}
+    try:
+        return mapping[fmt]
+    except KeyError as exc:
+        raise RuntimeError(f"Unknown transcript format: {fmt}") from exc
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    input_path = Path(args.input_path).expanduser()
+    output_dir = Path(args.output_dir).expanduser()
+
+    try:
+        transcript = read_transcript(str(input_path))
+    except Exception as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        chunks = make_chunks(transcript.cues, args.max_chars)
+    except Exception as exc:
+        print(f"Error preparing chunks: {exc}", file=sys.stderr)
+        return 1
+
+    target_dir = _resolve_output_directory(output_dir, args.flat)
+    log_path = target_dir / "homedoc.log"
+    logger = Logger(file_path=log_path, verbose=args.debug)
+    raw_lines: List[str] = []
+
+    def raw_handler(payload: str) -> None:
+        raw_lines.append(payload)
+
+    logger.log(f"Loaded transcript with {len(transcript.cues)} cues in {transcript.fmt.upper()} format")
+    logger.log(f"Planned {len(chunks)} chunk(s) with max {args.max_chars} characters")
+
+    try:
+        translate_range(
+            transcript,
+            chunks,
+            server=args.server,
+            model=args.model,
+            source=args.source,
+            target=args.target,
+            batch_n=args.batch_per_chunk,
+            translate_bracketed=args.translate_bracketed,
+            llm_mode=args.llm_mode,
+            stream=args.stream,
+            timeout=args.timeout,
+            no_llm=args.no_llm,
+            logger=logger.log,
+            raw_handler=raw_handler if (args.debug or args.stream) else None,
+            verbose=args.debug,
+        )
+    except Exception as exc:
+        logger.log(f"Translation failed: {exc}")
+        logger.close()
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    timestamp = dt.datetime.now(dt.timezone.utc).astimezone()
+    vtt_note = f"translated-with model={args.model} time={timestamp.isoformat()}"
+    try:
+        result = build_output(transcript, vtt_note=vtt_note if transcript.fmt == "vtt" else None)
+    except Exception as exc:
+        logger.log(f"Failed to render output: {exc}")
+        logger.close()
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    output_path = target_dir / _output_filename(transcript.fmt)
+    try:
+        _write_file(output_path, result)
+    except Exception as exc:
+        logger.log(str(exc))
+        logger.close()
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    logger.log(f"Wrote output to {output_path}")
+
+    if args.debug or args.stream:
+        raw_path = target_dir / "llm_raw.txt"
+        try:
+            raw_path.write_text("\n".join(raw_lines), encoding="utf-8")
+            logger.log(f"Captured raw LLM payloads in {raw_path}")
+        except OSError:
+            logger.log("Unable to write llm_raw.txt")
+
+    logger.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/setzer_core.py
+++ b/setzer_core.py
@@ -1,0 +1,777 @@
+"""Core logic for homedoc-subtitle-translator.
+
+This module keeps all parsing, formatting, chunking, and LLM communication in a
+single stdlib-only location so the CLI and GUI can share it without re-
+implementing behaviours.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass
+from typing import Callable, Dict, Iterable, List, Optional, Tuple
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+@dataclass
+class Cue:
+    index: int
+    start: str
+    end: str
+    text: str
+    translated: Optional[str] = None
+
+
+@dataclass
+class Transcript:
+    fmt: str
+    cues: List[Cue]
+    header: str = ""
+    tsv_header: Optional[List[str]] = None
+    tsv_cols: Optional[Tuple[int, int, int]] = None
+
+
+@dataclass
+class Chunk:
+    cid: int
+    start_idx: int
+    end_idx: int
+    charcount: int
+    status: str = "pending"
+    err: Optional[str] = None
+
+
+class TranscriptError(RuntimeError):
+    """Raised for parsing and formatting problems."""
+
+
+class LLMError(RuntimeError):
+    """Raised when the LLM could not be contacted or returned malformed data."""
+
+
+_FORMAT_GUESS_RE = {
+    "srt": re.compile(r"^\s*\d+\s*\n\s*\d\d:\d\d:\d\d[,\.]\d\d\d\s*-->", re.MULTILINE),
+    "vtt": re.compile(r"^\s*WEBVTT", re.IGNORECASE),
+    "tsv": re.compile(r"\t"),
+}
+
+
+def detect_format(text: str, filename: str = "") -> str:
+    """Heuristic format detection based on extension and content."""
+
+    ext = os.path.splitext(filename.lower())[1]
+    if ext in {".srt"}:
+        return "srt"
+    if ext in {".vtt"}:
+        return "vtt"
+    if ext in {".tsv", ".csv"}:
+        return "tsv"
+
+    stripped = text.lstrip()
+    if _FORMAT_GUESS_RE["vtt"].search(stripped):
+        return "vtt"
+    if _FORMAT_GUESS_RE["srt"].search(stripped):
+        return "srt"
+    if _FORMAT_GUESS_RE["tsv"].search(stripped):
+        return "tsv"
+    raise TranscriptError("Unable to detect subtitle format from input content.")
+
+
+def read_transcript(path: str) -> Transcript:
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            data = handle.read()
+    except OSError as exc:
+        raise TranscriptError(f"Unable to read input file: {exc}") from exc
+
+    if not data.strip():
+        raise TranscriptError("Input file is empty.")
+
+    fmt = detect_format(data, filename=path)
+    if fmt == "srt":
+        return parse_srt(data)
+    if fmt == "vtt":
+        return parse_vtt(data)
+    if fmt == "tsv":
+        return parse_tsv(data)
+    raise TranscriptError(f"Unsupported subtitle format: {fmt}")
+
+
+
+
+def _clean_lines(text: str) -> List[str]:
+    return text.replace("\r\n", "\n").replace("\r", "\n").split("\n")
+
+
+def parse_srt(text: str) -> Transcript:
+    lines = _clean_lines(text)
+    cues: List[Cue] = []
+    block: List[str] = []
+
+    def flush(block_lines: List[str]) -> None:
+        if not block_lines:
+            return
+        filtered = [line.replace("\ufeff", "") for line in block_lines]
+        while filtered and not filtered[0].strip():
+            filtered.pop(0)
+        while filtered and not filtered[-1].strip():
+            filtered.pop()
+        if len(filtered) < 2:
+            return
+        first = filtered[0].strip()
+        second = filtered[1] if len(filtered) > 1 else ""
+        text_start = 2
+        try:
+            idx = int(first)
+            time_line = second
+        except ValueError:
+            idx = len(cues) + 1
+            if "-->" in filtered[0]:
+                time_line = filtered[0]
+                text_start = 1
+            else:
+                time_line = filtered[1]
+        text_lines = filtered[text_start:]
+        start, end = _split_times(time_line)
+        cues.append(Cue(index=idx, start=start, end=end, text="\n".join(text_lines)))
+
+    for line in lines:
+        if line.strip() == "":
+            flush(block)
+            block = []
+        else:
+            block.append(line)
+    flush(block)
+
+    if not cues:
+        raise TranscriptError("No cues parsed from SRT file.")
+
+    return Transcript(fmt="srt", cues=cues)
+
+
+def parse_vtt(text: str) -> Transcript:
+    lines = _clean_lines(text)
+    header_lines: List[str] = []
+    cues: List[Cue] = []
+    block: List[str] = []
+    seen_header = False
+
+    for line in lines:
+        if not seen_header:
+            header_lines.append(line)
+            if line.strip() == "":
+                seen_header = True
+            continue
+        if line.strip() == "":
+            if block:
+                _flush_vtt_block(block, cues)
+                block = []
+        else:
+            block.append(line)
+    if block:
+        _flush_vtt_block(block, cues)
+
+    header = "\n".join(header_lines).strip("\n")
+    if not header.upper().startswith("WEBVTT"):
+        header = "WEBVTT" + ("\n" + header if header else "")
+
+    if not cues:
+        raise TranscriptError("No cues parsed from VTT file.")
+
+    return Transcript(fmt="vtt", cues=cues, header=header)
+
+
+def _flush_vtt_block(block: List[str], cues: List[Cue]) -> None:
+    if not block:
+        return
+    time_line = None
+    text_start = 0
+    if "-->" in block[0]:
+        time_line = block[0]
+        text_start = 1
+    else:
+        for idx, candidate in enumerate(block[1:], start=1):
+            if "-->" in candidate:
+                time_line = candidate
+                text_start = idx + 1
+                break
+    if not time_line:
+        return
+    start, end = _split_times(time_line)
+    text = "\n".join(block[text_start:])
+    index = len(cues) + 1
+    cues.append(Cue(index=index, start=start, end=end, text=text))
+
+
+def parse_tsv(text: str) -> Transcript:
+    import csv
+
+    reader = csv.reader(_clean_lines(text), delimiter="\t")
+    try:
+        header = next(reader)
+    except StopIteration as exc:
+        raise TranscriptError("TSV appears empty.") from exc
+
+    header_lower = [h.lower() for h in header]
+    start_idx, end_idx, text_idx = _infer_tsv_columns(header_lower)
+
+    cues: List[Cue] = []
+    for idx, row in enumerate(reader, start=1):
+        if not row:
+            continue
+        try:
+            start = row[start_idx]
+            end = row[end_idx]
+            text_val = row[text_idx]
+        except IndexError:
+            raise TranscriptError(
+                f"Row {idx} does not contain required columns (expected at least {text_idx+1} columns)."
+            )
+        cues.append(Cue(index=idx, start=start, end=end, text=text_val))
+
+    if not cues:
+        raise TranscriptError("No cues parsed from TSV file.")
+
+    return Transcript(fmt="tsv", cues=cues, tsv_header=header, tsv_cols=(start_idx, end_idx, text_idx))
+
+
+def _infer_tsv_columns(header_lower: List[str]) -> Tuple[int, int, int]:
+    start_idx = _first_with_keywords(header_lower, ["start", "begin"])
+    end_idx = _first_with_keywords(header_lower, ["end", "finish"])
+    text_idx = _first_with_keywords(header_lower, ["text", "subtitle", "caption", "transcript"])
+
+    if start_idx is None or end_idx is None or text_idx is None:
+        # Fall back to first three columns.
+        if len(header_lower) < 3:
+            raise TranscriptError("TSV header must contain at least three columns.")
+        return 0, 1, 2
+    return start_idx, end_idx, text_idx
+
+
+def _first_with_keywords(header: List[str], keywords: Iterable[str]) -> Optional[int]:
+    for idx, value in enumerate(header):
+        for key in keywords:
+            if key in value:
+                return idx
+    return None
+
+
+def _split_times(time_line: str) -> Tuple[str, str]:
+    parts = time_line.split("-->")
+    if len(parts) < 2:
+        raise TranscriptError(f"Unable to parse cue timing line: {time_line!r}")
+    start = parts[0].strip()
+    end_part = parts[1].strip().split()[0]
+    return start, end_part
+
+
+def write_srt(transcript: Transcript) -> str:
+    segments = []
+    for idx, cue in enumerate(transcript.cues, start=1):
+        text = cue.translated if cue.translated is not None else cue.text
+        segments.append(f"{idx}\n{cue.start} --> {cue.end}\n{text}")
+    return "\n\n".join(segments) + "\n"
+
+
+def write_vtt(transcript: Transcript, note: Optional[str] = None) -> str:
+    header = transcript.header or "WEBVTT"
+    lines = [header.strip()]
+    lines.append("")
+    if note:
+        lines.append(f"NOTE {note}")
+        lines.append("")
+    for cue in transcript.cues:
+        text = cue.translated if cue.translated is not None else cue.text
+        lines.append(f"{cue.start} --> {cue.end}")
+        lines.extend(text.split("\n"))
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def write_tsv(transcript: Transcript) -> str:
+    import csv
+    from io import StringIO
+
+    buffer = StringIO()
+    writer = csv.writer(buffer, delimiter="\t", lineterminator="\n")
+    header = transcript.tsv_header or ["start", "end", "text"]
+    writer.writerow(header)
+    start_idx, end_idx, text_idx = transcript.tsv_cols or (0, 1, 2)
+    for cue in transcript.cues:
+        row = [""] * max(len(header), text_idx + 1)
+        row[start_idx] = cue.start
+        row[end_idx] = cue.end
+        row[text_idx] = cue.translated if cue.translated is not None else cue.text
+        writer.writerow(row)
+    return buffer.getvalue()
+
+
+def build_output(transcript: Transcript, vtt_note: Optional[str] = None) -> str:
+    if transcript.fmt == "srt":
+        return write_srt(transcript)
+    if transcript.fmt == "vtt":
+        return write_vtt(transcript, note=vtt_note)
+    if transcript.fmt == "tsv":
+        return write_tsv(transcript)
+    raise TranscriptError(f"Cannot build output for unknown format: {transcript.fmt}")
+
+
+def make_chunks(cues: List[Cue], max_chars: int) -> List[Chunk]:
+    if max_chars <= 0:
+        raise ValueError("max_chars must be positive")
+    chunks: List[Chunk] = []
+    cid = 1
+    char_total = 0
+    start_pos = 0
+    for pos, cue in enumerate(cues):
+        text_len = len(cue.text)
+        if char_total and char_total + text_len > max_chars:
+            chunks.append(
+                Chunk(
+                    cid=cid,
+                    start_idx=start_pos + 1,
+                    end_idx=pos,
+                    charcount=char_total,
+                )
+            )
+            cid += 1
+            start_pos = pos
+            char_total = 0
+        char_total += text_len
+    if cues:
+        chunks.append(
+            Chunk(
+                cid=cid,
+                start_idx=start_pos + 1,
+                end_idx=len(cues),
+                charcount=char_total,
+            )
+        )
+    return chunks
+
+
+def _http_json(url: str, payload: Dict[str, object], timeout: float, *, stream: bool,
+               raw_handler: Optional[Callable[[str], None]] = None) -> str:
+    data = json.dumps(payload).encode("utf-8")
+    req = Request(url, data=data, headers={"Content-Type": "application/json"})
+    try:
+        with urlopen(req, timeout=timeout) as resp:
+            if not stream:
+                body = resp.read().decode("utf-8", errors="replace")
+                if raw_handler:
+                    raw_handler(body)
+                try:
+                    parsed = json.loads(body)
+                except json.JSONDecodeError as exc:
+                    raise LLMError(f"Malformed JSON response from server: {exc}") from exc
+                return _extract_message(parsed)
+            else:
+                pieces: List[str] = []
+                for raw_line in resp:
+                    line = raw_line.decode("utf-8", errors="replace").strip()
+                    if not line:
+                        continue
+                    if raw_handler:
+                        raw_handler(line)
+                    cleaned = line
+                    if cleaned.startswith("data:"):
+                        cleaned = cleaned[5:].strip()
+                    if not cleaned or cleaned == "[DONE]":
+                        continue
+                    try:
+                        parsed = json.loads(cleaned)
+                    except json.JSONDecodeError:
+                        continue
+                    piece = _extract_stream_piece(parsed)
+                    if piece:
+                        pieces.append(piece)
+                if not pieces:
+                    raise LLMError("Streamed response contained no usable content.")
+                return "".join(pieces)
+    except HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace") if exc.fp else ""
+        if raw_handler and detail:
+            raw_handler(detail)
+        raise LLMError(f"HTTP error {exc.code} from LLM server: {detail[:200]}") from exc
+    except URLError as exc:
+        raise LLMError(f"Failed to reach LLM server: {exc}") from exc
+
+
+def _extract_message(payload: Dict[str, object]) -> str:
+    if "message" in payload and isinstance(payload["message"], dict):
+        content = payload["message"].get("content")
+        if isinstance(content, str):
+            return content
+    if "messages" in payload and isinstance(payload["messages"], list):
+        messages = payload["messages"]
+        if messages:
+            content = messages[-1].get("content")
+            if isinstance(content, str):
+                return content
+    if "response" in payload and isinstance(payload["response"], str):
+        return payload["response"]
+    if "text" in payload and isinstance(payload["text"], str):
+        return payload["text"]
+    raise LLMError("LLM response missing message content.")
+
+
+def _extract_stream_piece(payload: Dict[str, object]) -> str:
+    if "message" in payload and isinstance(payload["message"], dict):
+        content = payload["message"].get("content")
+        if isinstance(content, str):
+            return content
+    if "response" in payload and isinstance(payload["response"], str):
+        return payload["response"]
+    if "text" in payload and isinstance(payload["text"], str):
+        return payload["text"]
+    return ""
+
+
+_TAG_RE = re.compile(r"<[^>]+>")
+_BRACKET_RE = re.compile(r"\[[^\]]+\]")
+
+
+def _protect_tags(text: str) -> Tuple[str, Dict[str, str]]:
+    mapping: Dict[str, str] = {}
+    counter = 0
+    def repl(match: re.Match[str]) -> str:
+        nonlocal counter
+        placeholder = f"__TAG{counter}__"
+        mapping[placeholder] = match.group(0)
+        counter += 1
+        return placeholder
+    protected = _TAG_RE.sub(repl, text)
+    return protected, mapping
+
+
+def _protect_brackets(text: str) -> Tuple[str, Dict[str, str]]:
+    mapping: Dict[str, str] = {}
+    counter = 0
+    def repl(match: re.Match[str]) -> str:
+        nonlocal counter
+        placeholder = f"__BR{counter}__"
+        mapping[placeholder] = match.group(0)
+        counter += 1
+        return placeholder
+    protected = _BRACKET_RE.sub(repl, text)
+    return protected, mapping
+
+
+def _restore_placeholders(text: str, mapping: Dict[str, str]) -> str:
+    for placeholder, value in mapping.items():
+        text = text.replace(placeholder, value)
+    return text
+
+
+def llm_translate_single(
+    text: str,
+    *,
+    source: str,
+    target: str,
+    model: str,
+    server: str,
+    translate_bracketed: bool,
+    llm_mode: str,
+    stream: bool,
+    timeout: float,
+    raw_handler: Optional[Callable[[str], None]] = None,
+) -> str:
+    prepared, tag_map = _protect_tags(text)
+    bracket_map: Dict[str, str] = {}
+    if not translate_bracketed:
+        prepared, bracket_map = _protect_brackets(prepared)
+
+    prompt = (
+        "Translate the following subtitle cue from {src} to {dst}. "
+        "Preserve placeholders, formatting, and whitespace exactly."
+    ).format(src=source or "auto-detected language", dst=target)
+
+    body = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": "You are a precise subtitle translator."},
+            {
+                "role": "user",
+                "content": f"{prompt}\n\nCUE:\n{prepared}",
+            },
+        ],
+        "stream": stream,
+    }
+
+    raw_result = _perform_llm_call(
+        server=server,
+        mode=llm_mode,
+        body=body,
+        generate_prompt=f"{prompt}\n\n{prepared}",
+        stream=stream,
+        timeout=timeout,
+        raw_handler=raw_handler,
+    )
+
+    if not raw_result:
+        return text
+    if not raw_result.strip():
+        return text
+    return _restore_placeholders(raw_result, {**tag_map, **bracket_map})
+
+
+def llm_translate_batch(
+    pairs: List[Tuple[str, str]],
+    *,
+    source: str,
+    target: str,
+    model: str,
+    server: str,
+    llm_mode: str,
+    stream: bool,
+    timeout: float,
+    translate_bracketed: bool,
+    raw_handler: Optional[Callable[[str], None]] = None,
+) -> List[Tuple[str, str]]:
+    protected_pairs: List[Tuple[str, str, Dict[str, str], Dict[str, str]]] = []
+    inputs: List[str] = []
+    for pid, text in pairs:
+        prepared, tag_map = _protect_tags(text)
+        bracket_map: Dict[str, str] = {}
+        if not translate_bracketed:
+            prepared, bracket_map = _protect_brackets(prepared)
+        inputs.append(f"{pid}|||{prepared}")
+        protected_pairs.append((pid, prepared, tag_map, bracket_map))
+
+    instructions = (
+        "Translate each input line from {src} to {dst}. "
+        "Return one line per input in the form ID|||TRANSLATION. "
+        "Preserve placeholders and whitespace."
+    ).format(src=source or "auto-detected language", dst=target)
+
+    joined = "\n".join(inputs)
+    body = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": "You translate subtitles in bulk."},
+            {
+                "role": "user",
+                "content": f"{instructions}\n\nINPUT:\n{joined}",
+            },
+        ],
+        "stream": stream,
+    }
+
+    result = _perform_llm_call(
+        server=server,
+        mode=llm_mode,
+        body=body,
+        generate_prompt=f"{instructions}\n\n{joined}",
+        stream=stream,
+        timeout=timeout,
+        raw_handler=raw_handler,
+    )
+
+    mapping: Dict[str, str] = {}
+    for line in result.splitlines():
+        if "|||" not in line:
+            continue
+        pid, translated = line.split("|||", 1)
+        mapping[pid.strip()] = translated
+
+    output: List[Tuple[str, str]] = []
+    for pid, prepared, tag_map, bracket_map in protected_pairs:
+        translated = mapping.get(pid)
+        if translated is None:
+            restored = _restore_placeholders(prepared, {**tag_map, **bracket_map})
+        else:
+            restored = _restore_placeholders(translated, {**tag_map, **bracket_map})
+        output.append((pid, restored))
+    return output
+
+
+def _perform_llm_call(
+    *,
+    server: str,
+    mode: str,
+    body: Dict[str, object],
+    generate_prompt: str,
+    stream: bool,
+    timeout: float,
+    raw_handler: Optional[Callable[[str], None]] = None,
+) -> str:
+    mode = (mode or "auto").lower()
+    errors: List[str] = []
+
+    def request_chat() -> str:
+        url = server.rstrip("/") + "/api/chat"
+        return _http_json(url, body, timeout, stream=stream, raw_handler=raw_handler)
+
+    def request_generate() -> str:
+        payload = {
+            "model": body.get("model"),
+            "prompt": generate_prompt,
+            "stream": stream,
+        }
+        url = server.rstrip("/") + "/api/generate"
+        return _http_json(url, payload, timeout, stream=stream, raw_handler=raw_handler)
+
+    if mode == "chat":
+        return request_chat()
+    if mode == "generate":
+        return request_generate()
+    # auto: try chat then generate.
+    try:
+        return request_chat()
+    except LLMError as exc:
+        errors.append(str(exc))
+        return request_generate()
+
+
+def translate_range(
+    transcript: Transcript,
+    chunks: List[Chunk],
+    *,
+    server: str,
+    model: str,
+    source: str,
+    target: str,
+    batch_n: int,
+    translate_bracketed: bool,
+    llm_mode: str,
+    stream: bool,
+    timeout: float,
+    no_llm: bool = False,
+    logger: Optional[Callable[[str], None]] = None,
+    raw_handler: Optional[Callable[[str], None]] = None,
+    verbose: bool = False,
+) -> None:
+    if batch_n < 1:
+        raise ValueError("batch_n must be >= 1")
+
+    for chunk in chunks:
+        if logger and verbose:
+            logger(
+                f"Processing chunk {chunk.cid} covering cues {chunk.start_idx}-{chunk.end_idx}"
+            )
+        start = chunk.start_idx - 1
+        end = chunk.end_idx
+        cues_slice = transcript.cues[start:end]
+        try:
+            if no_llm:
+                for cue in cues_slice:
+                    cue.translated = cue.text
+                chunk.status = "done"
+                continue
+            if batch_n == 1:
+                for cue in cues_slice:
+                    translated = llm_translate_single(
+                        cue.text,
+                        source=source,
+                        target=target,
+                        model=model,
+                        server=server,
+                        translate_bracketed=translate_bracketed,
+                        llm_mode=llm_mode,
+                        stream=stream,
+                        timeout=timeout,
+                        raw_handler=raw_handler,
+                    )
+                    if translated:
+                        cue.translated = translated
+                    else:
+                        cue.translated = cue.text
+                        if logger:
+                            logger(
+                                f"Warning: empty translation for cue {cue.index}; reused original text"
+                            )
+            else:
+                batch: List[Tuple[str, str]] = []
+                for cue in cues_slice:
+                    batch.append((str(cue.index), cue.text))
+                    if len(batch) == batch_n:
+                        missing = _apply_batch(
+                            batch,
+                            cues_slice,
+                            source,
+                            target,
+                            model,
+                            server,
+                            llm_mode,
+                            stream,
+                            timeout,
+                            translate_bracketed,
+                            raw_handler,
+                        )
+                        if missing and logger:
+                            logger(
+                                "Warning: missing translations for IDs "
+                                + ", ".join(missing)
+                            )
+                        batch = []
+                if batch:
+                    missing = _apply_batch(
+                        batch,
+                        cues_slice,
+                        source,
+                        target,
+                        model,
+                        server,
+                        llm_mode,
+                        stream,
+                        timeout,
+                        translate_bracketed,
+                        raw_handler,
+                    )
+                    if missing and logger:
+                        logger(
+                            "Warning: missing translations for IDs "
+                            + ", ".join(missing)
+                        )
+            chunk.status = "done"
+        except LLMError as exc:
+            chunk.status = "error"
+            chunk.err = str(exc)
+            if logger:
+                logger(f"Error processing chunk {chunk.cid}: {exc}")
+            raise RuntimeError(f"Chunk {chunk.cid} failed: {exc}") from exc
+
+
+def _apply_batch(
+    batch: List[Tuple[str, str]],
+    cues_slice: List[Cue],
+    source: str,
+    target: str,
+    model: str,
+    server: str,
+    llm_mode: str,
+    stream: bool,
+    timeout: float,
+    translate_bracketed: bool,
+    raw_handler: Optional[Callable[[str], None]],
+) -> List[str]:
+    translated_pairs = llm_translate_batch(
+        batch,
+        source=source,
+        target=target,
+        model=model,
+        server=server,
+        llm_mode=llm_mode,
+        stream=stream,
+        timeout=timeout,
+        translate_bracketed=translate_bracketed,
+        raw_handler=raw_handler,
+    )
+    mapping = {pid: text for pid, text in translated_pairs}
+    cue_index = {str(cue.index): cue for cue in cues_slice}
+    missing: List[str] = []
+    for pid, _ in batch:
+        cue = cue_index.get(pid)
+        if not cue:
+            missing.append(pid)
+            continue
+        translated = mapping.get(pid)
+        if translated is None or not translated.strip():
+            cue.translated = cue.text
+            missing.append(pid)
+        else:
+            cue.translated = translated
+    return missing
+

--- a/setzer_gui.py
+++ b/setzer_gui.py
@@ -1,0 +1,283 @@
+"""Optional Tk GUI for homedoc-subtitle-translator."""
+from __future__ import annotations
+
+import datetime as dt
+import os
+import queue
+import threading
+import tkinter as tk
+from pathlib import Path
+from tkinter import filedialog, messagebox, scrolledtext
+from typing import List, Optional
+
+from setzer_core import (
+    Chunk,
+    Transcript,
+    build_output,
+    make_chunks,
+    read_transcript,
+    translate_range,
+)
+
+
+class App:
+    def __init__(self, root: tk.Tk) -> None:
+        self.root = root
+        root.title("homedoc-subtitle-translator")
+
+        self.input_var = tk.StringVar()
+        self.output_var = tk.StringVar()
+        self.source_var = tk.StringVar(value="auto")
+        self.target_var = tk.StringVar(value="English")
+        self.server_var = tk.StringVar(value="http://127.0.0.1:11434")
+        self.model_var = tk.StringVar(value="gemma3:12b")
+        self.batch_var = tk.IntVar(value=1)
+        self.max_chars_var = tk.IntVar(value=4000)
+        self.bracket_var = tk.BooleanVar(value=True)
+        self.stream_var = tk.BooleanVar(value=True)
+        self.flat_var = tk.BooleanVar(value=False)
+        self.no_llm_var = tk.BooleanVar(value=False)
+
+        self.log_queue: "queue.Queue[str]" = queue.Queue()
+        self.transcript: Optional[Transcript] = None
+        self.chunks: List[Chunk] = []
+        self.abort_event = threading.Event()
+        self.worker: Optional[threading.Thread] = None
+
+        self._build_layout()
+        self.root.protocol("WM_DELETE_WINDOW", self.on_close)
+        self.root.after(150, self._drain_logs)
+
+    def _build_layout(self) -> None:
+        frame = tk.Frame(self.root)
+        frame.pack(fill=tk.BOTH, expand=True, padx=10, pady=10)
+
+        def add_row(label: str, widget: tk.Widget, row: int) -> None:
+            tk.Label(frame, text=label).grid(row=row, column=0, sticky="w", padx=(0, 6))
+            widget.grid(row=row, column=1, sticky="ew")
+
+        frame.columnconfigure(1, weight=1)
+
+        # Input path
+        input_entry = tk.Entry(frame, textvariable=self.input_var)
+        add_row("Input", input_entry, 0)
+        tk.Button(frame, text="Browse", command=self._browse_input).grid(row=0, column=2, padx=(6, 0))
+
+        # Output directory
+        output_entry = tk.Entry(frame, textvariable=self.output_var)
+        add_row("Output", output_entry, 1)
+        tk.Button(frame, text="Browse", command=self._browse_output).grid(row=1, column=2, padx=(6, 0))
+
+        add_row("Source", tk.Entry(frame, textvariable=self.source_var), 2)
+        add_row("Target", tk.Entry(frame, textvariable=self.target_var), 3)
+        add_row("Server", tk.Entry(frame, textvariable=self.server_var), 4)
+        add_row("Model", tk.Entry(frame, textvariable=self.model_var), 5)
+        add_row("Batch/chunk", tk.Entry(frame, textvariable=self.batch_var), 6)
+        add_row("Max chars", tk.Entry(frame, textvariable=self.max_chars_var), 7)
+
+        options_frame = tk.Frame(frame)
+        options_frame.grid(row=8, column=0, columnspan=3, sticky="w", pady=(4, 4))
+        tk.Checkbutton(options_frame, text="Translate bracketed", variable=self.bracket_var).pack(side=tk.LEFT)
+        tk.Checkbutton(options_frame, text="Stream", variable=self.stream_var).pack(side=tk.LEFT, padx=(10, 0))
+        tk.Checkbutton(options_frame, text="Flat output", variable=self.flat_var).pack(side=tk.LEFT, padx=(10, 0))
+        tk.Checkbutton(options_frame, text="Dry run (no LLM)", variable=self.no_llm_var).pack(side=tk.LEFT, padx=(10, 0))
+
+        self.chunk_list = tk.Listbox(frame, height=6)
+        frame.rowconfigure(9, weight=1)
+        self.chunk_list.grid(row=9, column=0, columnspan=3, sticky="nsew", pady=(6, 6))
+
+        button_frame = tk.Frame(frame)
+        button_frame.grid(row=10, column=0, columnspan=3, sticky="ew", pady=(4, 4))
+        tk.Button(button_frame, text="Build/Update chunks", command=self.build_chunks).pack(side=tk.LEFT)
+        tk.Button(button_frame, text="Translate ALL", command=self.translate_all).pack(side=tk.LEFT, padx=(6, 0))
+        tk.Button(button_frame, text="Translate selected chunk", command=self.translate_selected).pack(side=tk.LEFT, padx=(6, 0))
+        tk.Button(button_frame, text="Abort", command=self.abort).pack(side=tk.LEFT, padx=(6, 0))
+
+        self.console = scrolledtext.ScrolledText(frame, height=12, state=tk.DISABLED)
+        self.console.grid(row=11, column=0, columnspan=3, sticky="nsew")
+        frame.rowconfigure(11, weight=2)
+
+    def _browse_input(self) -> None:
+        filename = filedialog.askopenfilename(filetypes=[("Subtitles", "*.srt *.vtt *.tsv"), ("All", "*.*")])
+        if filename:
+            self.input_var.set(filename)
+
+    def _browse_output(self) -> None:
+        directory = filedialog.askdirectory()
+        if directory:
+            self.output_var.set(directory)
+
+    def log(self, message: str) -> None:
+        timestamp = dt.datetime.now().isoformat(timespec="seconds")
+        self.log_queue.put(f"[{timestamp}] {message}")
+
+    def _drain_logs(self) -> None:
+        while True:
+            try:
+                line = self.log_queue.get_nowait()
+            except queue.Empty:
+                break
+            self.console.configure(state=tk.NORMAL)
+            self.console.insert(tk.END, line + "\n")
+            self.console.configure(state=tk.DISABLED)
+            self.console.see(tk.END)
+        self.root.after(150, self._drain_logs)
+
+    def build_chunks(self) -> None:
+        if self.worker and self.worker.is_alive():
+            messagebox.showwarning("Busy", "Wait for the current job to finish or abort it first.")
+            return
+        input_path = self.input_var.get().strip()
+        if not input_path:
+            messagebox.showerror("Missing input", "Please choose an input subtitle file.")
+            return
+        try:
+            transcript = read_transcript(input_path)
+            chunks = make_chunks(transcript.cues, int(self.max_chars_var.get()))
+        except Exception as exc:
+            self.log(f"Failed to load transcript: {exc}")
+            messagebox.showerror("Error", str(exc))
+            return
+        self.transcript = transcript
+        self.chunks = chunks
+        self.chunk_list.delete(0, tk.END)
+        for chunk in chunks:
+            self.chunk_list.insert(tk.END, f"Chunk {chunk.cid}: cues {chunk.start_idx}-{chunk.end_idx} ({chunk.charcount} chars)")
+        self.log(f"Loaded {len(transcript.cues)} cues and planned {len(chunks)} chunk(s)")
+
+    def translate_all(self) -> None:
+        if not self._ensure_ready():
+            return
+        self._start_worker(self.chunks)
+
+    def translate_selected(self) -> None:
+        if not self._ensure_ready():
+            return
+        selection = self.chunk_list.curselection()
+        if not selection:
+            messagebox.showinfo("Select chunk", "Choose a chunk from the list first.")
+            return
+        index = selection[0]
+        chunk = self.chunks[index]
+        self._start_worker([chunk])
+
+    def _ensure_ready(self) -> bool:
+        if self.worker and self.worker.is_alive():
+            messagebox.showwarning("Busy", "Worker already running. Abort it first.")
+            return False
+        if self.transcript is None or not self.chunks:
+            messagebox.showinfo("Need chunks", "Build chunks before running translation.")
+            return False
+        if not self.output_var.get().strip():
+            messagebox.showinfo("Output", "Choose an output directory first.")
+            return False
+        return True
+
+    def _start_worker(self, subset: List[Chunk]) -> None:
+        self.abort_event.clear()
+        try:
+            batch_n = max(1, int(self.batch_var.get()))
+        except (TypeError, ValueError):
+            messagebox.showerror("Invalid batch size", "Batch per chunk must be an integer >= 1.")
+            return
+        args = dict(
+            server=self.server_var.get().strip(),
+            model=self.model_var.get().strip(),
+            source=self.source_var.get().strip(),
+            target=self.target_var.get().strip(),
+            batch_n=batch_n,
+            translate_bracketed=self.bracket_var.get(),
+            llm_mode="auto",
+            stream=self.stream_var.get(),
+            timeout=60.0,
+            no_llm=self.no_llm_var.get(),
+        )
+        output_dir = Path(self.output_var.get()).expanduser()
+        flat = self.flat_var.get()
+        model_tag = self.model_var.get().strip()
+
+        def run() -> None:
+            self.log("Starting translation job")
+            processed_any = False
+            for chunk in subset:
+                if self.abort_event.is_set():
+                    self.log("Translation aborted by user")
+                    break
+                try:
+                    translate_range(
+                        self.transcript,
+                        [chunk],
+                        logger=self.log,
+                        raw_handler=None,
+                        verbose=True,
+                        **args,
+                    )
+                    processed_any = True
+                    self.log(f"Finished chunk {chunk.cid}")
+                except Exception as exc:
+                    self.log(f"Chunk {chunk.cid} failed: {exc}")
+                    self.root.after(0, lambda msg=str(exc): messagebox.showerror("Translation error", msg))
+                    break
+            if processed_any and not self.abort_event.is_set():
+                self._write_outputs(output_dir, flat, model_tag)
+            self.worker = None
+
+        self.worker = threading.Thread(target=run, daemon=True)
+        self.worker.start()
+
+    def _write_outputs(self, output_dir: Path, flat: bool, model_tag: str) -> None:
+        assert self.transcript is not None
+        target = self._resolve_output_directory(output_dir, flat)
+        timestamp = dt.datetime.now(dt.timezone.utc).astimezone()
+        note = f"translated-with model={model_tag} time={timestamp.isoformat()}"
+        content = build_output(self.transcript, vtt_note=note if self.transcript.fmt == "vtt" else None)
+        filename = self._output_filename(self.transcript.fmt)
+        path = target / filename
+        try:
+            path.write_text(content, encoding="utf-8")
+            self.log(f"Wrote output to {path}")
+        except OSError as exc:
+            self.log(f"Unable to write output: {exc}")
+
+    def _resolve_output_directory(self, base: Path, flat: bool) -> Path:
+        if flat:
+            base.mkdir(parents=True, exist_ok=True)
+            return base
+        env_tz = os.getenv("HOMEDOC_TZ")
+        now = dt.datetime.now()
+        if env_tz:
+            try:
+                from zoneinfo import ZoneInfo
+
+                tz = ZoneInfo(env_tz)
+                now = dt.datetime.now(tz)
+            except Exception:
+                pass
+        folder = now.strftime("%Y%m%d-%H%M%S")
+        target = base / folder
+        target.mkdir(parents=True, exist_ok=True)
+        return target
+
+    def _output_filename(self, fmt: str) -> str:
+        mapping = {"srt": "report.srt", "vtt": "report.vtt", "tsv": "report.tsv"}
+        return mapping.get(fmt, "report.txt")
+
+    def abort(self) -> None:
+        self.abort_event.set()
+        self.log("Abort requested")
+
+    def on_close(self) -> None:
+        self.abort()
+        if self.worker and self.worker.is_alive():
+            self.worker.join(timeout=1)
+        self.root.destroy()
+
+
+def main() -> None:
+    root = tk.Tk()
+    app = App(root)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_setzer_core.py
+++ b/tests/test_setzer_core.py
@@ -1,0 +1,221 @@
+import unittest
+from unittest import mock
+
+import setzer_core
+from setzer_core import Cue, _apply_batch
+
+
+class FakeStreamResponse:
+    def __init__(self, lines):
+        self._lines = [line.encode("utf-8") for line in lines]
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def __iter__(self):
+        return iter(self._lines)
+
+
+class ApplyBatchTests(unittest.TestCase):
+    def setUp(self):
+        self.original_batch = [("1", "Hello"), ("2", "World"), ("3", "Foo"), ("4", "Bar")]
+        self.cues = [
+            Cue(index=1, start="0", end="1", text="Hello"),
+            Cue(index=2, start="1", end="2", text="World"),
+            Cue(index=3, start="2", end="3", text="Foo"),
+            Cue(index=4, start="3", end="4", text="Bar"),
+        ]
+
+    def test_apply_batch_only_updates_present_ids(self):
+        batches = iter([
+            [("1", "Hola"), ("2", "Mundo")],
+            [("3", "Baz"), ("4", "Qux")],
+        ])
+
+        def fake_batch(request_batch, **_):
+            return next(batches)
+
+        with mock.patch.object(setzer_core, "llm_translate_batch", side_effect=fake_batch):
+            missing_first = _apply_batch(
+                self.original_batch[:2],
+                self.cues,
+                "",
+                "",
+                "",
+                "",
+                "auto",
+                False,
+                30,
+                True,
+                None,
+            )
+            self.assertEqual(missing_first, [])
+            self.assertEqual(self.cues[0].translated, "Hola")
+            self.assertEqual(self.cues[1].translated, "Mundo")
+            # Remaining cues untouched
+            self.assertIsNone(self.cues[2].translated)
+            self.assertIsNone(self.cues[3].translated)
+
+            missing_second = _apply_batch(
+                self.original_batch[2:],
+                self.cues,
+                "",
+                "",
+                "",
+                "",
+                "auto",
+                False,
+                30,
+                True,
+                None,
+            )
+            self.assertEqual(missing_second, [])
+            self.assertEqual(self.cues[2].translated, "Baz")
+            self.assertEqual(self.cues[3].translated, "Qux")
+
+    def test_apply_batch_marks_missing_ids(self):
+        def fake_batch(request_batch, **_):
+            return [request_batch[0]]  # drop others
+
+        with mock.patch.object(setzer_core, "llm_translate_batch", side_effect=fake_batch):
+            missing = _apply_batch(
+                self.original_batch[:2],
+                self.cues,
+                "",
+                "",
+                "",
+                "",
+                "auto",
+                False,
+                30,
+                True,
+                None,
+            )
+            self.assertEqual(missing, ["2"])
+            self.assertEqual(self.cues[0].translated, "Hello")  # from fake translation
+            self.assertEqual(self.cues[1].translated, "World")  # reused original text
+
+
+    def test_apply_batch_treats_blank_translations_as_missing(self):
+        def fake_batch(request_batch, **_):
+            return [
+                (request_batch[0][0], "  Hola  "),
+                (request_batch[1][0], "   "),
+            ]
+
+        with mock.patch.object(setzer_core, "llm_translate_batch", side_effect=fake_batch):
+            missing = _apply_batch(
+                self.original_batch[:2],
+                self.cues,
+                "",
+                "",
+                "",
+                "",
+                "auto",
+                False,
+                30,
+                True,
+                None,
+            )
+            self.assertEqual(missing, ["2"])
+            self.assertEqual(self.cues[0].translated, "  Hola  ")
+            self.assertEqual(self.cues[1].translated, "World")
+
+
+class HttpJsonStreamTests(unittest.TestCase):
+    def test_streaming_data_prefix_handling(self):
+        lines = [
+            "data: {\"message\": {\"content\": \"Hel\"}}",
+            "data: {\"message\": {\"content\": \"lo\"}}",
+            "data: [DONE]",
+        ]
+        fake_response = FakeStreamResponse(lines)
+        collector = []
+
+        def fake_urlopen(req, timeout):
+            return fake_response
+
+        with mock.patch("setzer_core.urlopen", side_effect=fake_urlopen):
+            result = setzer_core._http_json(
+                "http://example/api/chat",
+                {"a": 1},
+                10,
+                stream=True,
+                raw_handler=collector.append,
+            )
+
+        self.assertEqual(result, "Hello")
+        self.assertEqual(collector, lines)
+
+
+class TranslationWhitespaceTests(unittest.TestCase):
+    def test_llm_translate_single_preserves_whitespace(self):
+        original = "  Hello world  \n"
+
+        with mock.patch(
+            "setzer_core._perform_llm_call",
+            return_value="  Bonjour le monde  \n",
+        ):
+            translated = setzer_core.llm_translate_single(
+                original,
+                source="en",
+                target="fr",
+                model="gemma",
+                server="http://example",
+                translate_bracketed=True,
+                llm_mode="chat",
+                stream=False,
+                timeout=10,
+            )
+
+        self.assertEqual(translated, "  Bonjour le monde  \n")
+
+    def test_llm_translate_single_falls_back_on_blank_content(self):
+        original = "Keep me"
+
+        with mock.patch(
+            "setzer_core._perform_llm_call",
+            return_value="   \n\t  ",
+        ):
+            translated = setzer_core.llm_translate_single(
+                original,
+                source="en",
+                target="fr",
+                model="gemma",
+                server="http://example",
+                translate_bracketed=True,
+                llm_mode="chat",
+                stream=False,
+                timeout=10,
+            )
+
+        self.assertEqual(translated, original)
+
+    def test_llm_translate_batch_preserves_whitespace(self):
+        pairs = [("1", "Hello"), ("2", "World")]
+        response = "1|||  Salut  \n2|||Monde\n"
+
+        with mock.patch(
+            "setzer_core._perform_llm_call",
+            return_value=response,
+        ):
+            translated_pairs = setzer_core.llm_translate_batch(
+                pairs,
+                source="en",
+                target="fr",
+                model="gemma",
+                server="http://example",
+                llm_mode="chat",
+                stream=False,
+                timeout=10,
+                translate_bracketed=True,
+            )
+
+        self.assertEqual(translated_pairs, [("1", "  Salut  "), ("2", "Monde")])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Implemented setzer_core to parse SRT/VTT/TSV subtitles, plan translation chunks, and drive LLM calls with streaming-aware HTTP handling, placeholder preservation, and batch fallbacks.
- Added the homedoc-style setzer CLI with environment-driven defaults, logging, artifact management, and packaging metadata for distribution.
- Documented usage and delivered an optional Tk GUI wrapper that reuses the core workflow for chunk planning and translations.
- Documented how to run the CLI without installation and added dedicated update/remove sections in the README for pipx and pip workflows.
- Documented how to run the CLI without installation and added dedicated update/remove sections in the README for pipx and pip workflows.
- add a project .gitignore covering bytecode, build artifacts, and virtualenvs
- ignore homedoc.log, llm_raw.txt, and common output folders produced by the CLI

## Testing
- python -m compileall setzer_core.py setzer_cli.py setzer_gui.py

------
https://chatgpt.com/codex/tasks/task_b_68dd6a81d288832cb34ad3e723e67267