### PR TITLE
Add GUI and CLI controls for cue batching

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -12,7 +12,7 @@ available through the `homedoc-subtitle-translator` alias as well.
 | `--flat` / `--no-flat` | bool | `--no-flat` | – | Write directly into `--out` or into a timestamped subfolder. |
 | `--source` | text | `auto` | – | Source language hint. |
 | `--target` | text | `English` | – | Target language. |
-| `--batch-per-chunk` | int | `1` | – | Number of cues per LLM request when chunking. |
+| `--cues-per-request` / `--batch-per-chunk` | int | `1` | `HOMEDOC_CUES_PER_REQUEST` | Subtitle cues per LLM request. |
 | `--max-chars` | int | `4000` | – | Planning size for chunk generation. |
 | `--no-translate-bracketed` | bool | disabled | – | Preserve bracketed tags such as `[MUSIC]`. |
 | `--server` | URL | `http://127.0.0.1:11434` | `HOMEDOC_LLM_SERVER` | Ollama-compatible server URL. |
@@ -52,7 +52,7 @@ setzer --in talk.vtt --out ./translated --flat
 ### Batch mode
 
 ```bash
-setzer --in lessons.srt --out ./translated --batch-per-chunk 8 --max-chars 6000
+setzer --in lessons.srt --out ./translated --cues-per-request 8 --max-chars 6000
 ```
 
 ### Preserve bracketed tags

--- a/setzer_cli.py
+++ b/setzer_cli.py
@@ -67,6 +67,10 @@ def _build_parser() -> argparse.ArgumentParser:
     mode_default = _env_value("HOMEDOC_LLM_MODE", "auto")
     stream_default = _env_bool("HOMEDOC_STREAM", True)
     timeout_default = float(_env_value("HOMEDOC_HTTP_TIMEOUT", "60"))
+    try:
+        cues_default = int(_env_value("HOMEDOC_CUES_PER_REQUEST", "1"))
+    except ValueError:
+        cues_default = 1
 
     parser = argparse.ArgumentParser(
         description="Translate subtitle files using a local Ollama-compatible LLM.",
@@ -88,10 +92,12 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--source", default="auto", help="Source language (default: %(default)s)")
     parser.add_argument("--target", default="English", help="Target language (default: %(default)s)")
     parser.add_argument(
+        "--cues-per-request",
         "--batch-per-chunk",
+        dest="cues_per_request",
         type=int,
-        default=1,
-        help="Number of cues to send per LLM request (default: %(default)s)",
+        default=cues_default,
+        help="Number of subtitle cues to send per LLM request (default: %(default)s)",
     )
     parser.add_argument(
         "--max-chars",
@@ -233,7 +239,7 @@ def main(argv: Optional[List[str]] = None) -> int:
             model=args.model,
             source=args.source,
             target=args.target,
-            batch_n=args.batch_per_chunk,
+            batch_n=args.cues_per_request,
             translate_bracketed=args.translate_bracketed,
             llm_mode=args.llm_mode,
             stream=args.stream,

--- a/setzer_gui.py
+++ b/setzer_gui.py
@@ -32,7 +32,7 @@ class App:
         self.target_var = tk.StringVar(value="English")
         self.server_var = tk.StringVar(value="http://127.0.0.1:11434")
         self.model_var = tk.StringVar(value="gemma3:12b")
-        self.batch_var = tk.IntVar(value=1)
+        self.cues_per_request_var = tk.IntVar(value=1)
         self.max_chars_var = tk.IntVar(value=4000)
         self.bracket_var = tk.BooleanVar(value=True)
         self.stream_var = tk.BooleanVar(value=True)
@@ -74,7 +74,8 @@ class App:
         add_row("Target", tk.Entry(frame, textvariable=self.target_var), 3)
         add_row("Server", tk.Entry(frame, textvariable=self.server_var), 4)
         add_row("Model", tk.Entry(frame, textvariable=self.model_var), 5)
-        add_row("Batch/chunk", tk.Entry(frame, textvariable=self.batch_var), 6)
+        cues_spin = tk.Spinbox(frame, from_=1, to=50, textvariable=self.cues_per_request_var, width=6)
+        add_row("Cues/request", cues_spin, 6)
         add_row("Max chars", tk.Entry(frame, textvariable=self.max_chars_var), 7)
 
         options_frame = tk.Frame(frame)
@@ -179,9 +180,12 @@ class App:
     def _start_worker(self, subset: List[Chunk]) -> None:
         self.abort_event.clear()
         try:
-            batch_n = max(1, int(self.batch_var.get()))
+            batch_n = max(1, int(self.cues_per_request_var.get()))
         except (TypeError, ValueError):
-            messagebox.showerror("Invalid batch size", "Batch per chunk must be an integer >= 1.")
+            messagebox.showerror(
+                "Invalid batch size",
+                "Cues per request must be an integer >= 1.",
+            )
             return
         args = dict(
             server=self.server_var.get().strip(),


### PR DESCRIPTION
## Summary
- add a clearer `--cues-per-request` CLI flag (aliasing the existing batch flag) and support the `HOMEDOC_CUES_PER_REQUEST` default
- expose the cue batching control in the Tk GUI with a spinbox for easier adjustment
- document the new flag name and environment variable in the usage guide

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68dda8860e8c832cb77e5705644b84dc