### PR TITLE
Add output format and template options to CLI and GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ setzer \
 
 # disable streaming
 setzer --in demo.vtt --out ./out --no-stream
+
+# custom output format and template
+setzer --in demo.vtt --out ./out --outfmt vtt --outfile "~/subs/{basename}.{dst}.{fmt}"
+
+# include timestamp in the output path
+setzer --in demo.vtt --out ./out --outfile "~/subs/{basename}.{dst}.{fmt}.{ts}"
 ```
 
 See [USAGE.md](USAGE.md) for the full flag reference and examples.
@@ -82,14 +88,17 @@ behaviour.
 
 ## Outputs
 
-Every CLI invocation writes:
+Every CLI invocation writes the translated subtitle file plus:
 
-- `report.<ext>` — rewritten subtitle file matching the input format.
 - `homedoc.log` — timestamped log of the run.
 - `llm_raw.txt` — raw LLM payloads when streaming or `--debug` is active.
 
-By default results are placed in `--out/<YYYYMMDD-HHMMSS>/`. Use `--flat` to
-write directly into the specified output directory.
+The main subtitle file defaults to `{basename}.{dst}.{fmt}` (input stem,
+target language, and chosen format). Use `--outfmt` to convert formats and
+`--outfile` to override the template. Available placeholders are
+`{basename}`, `{src}`, `{dst}`, `{fmt}`, and `{ts}` (local timestamp). When
+`--flat` is disabled the template is evaluated inside the timestamped
+subdirectory `--out/<YYYYMMDD-HHMMSS>/`.
 
 ## Notes & Safety
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -10,6 +10,8 @@ available through the `homedoc-subtitle-translator` alias as well.
 | `--in` | path | required | – | Input subtitle (`.srt`, `.vtt`, `.tsv`). |
 | `--out` | path | required | – | Output directory. |
 | `--flat` / `--no-flat` | bool | `--no-flat` | – | Write directly into `--out` or into a timestamped subfolder. |
+| `--outfmt` | choice | `auto` | – | Output format (`srt`, `vtt`, `tsv`, or `auto`). |
+| `--outfile` | text | `{basename}.{dst}.{fmt}` | – | Output template supporting `{basename}`, `{src}`, `{dst}`, `{fmt}`, `{ts}`. |
 | `--source` | text | `auto` | – | Source language hint. |
 | `--target` | text | `English` | – | Target language. |
 | `--cues-per-request` / `--batch-per-chunk` | int | `1` | `HOMEDOC_CUES_PER_REQUEST` | Subtitle cues per LLM request. |
@@ -27,7 +29,9 @@ available through the `homedoc-subtitle-translator` alias as well.
 Environment variables provide defaults when the related flags are omitted. If
 `HOMEDOC_STREAM` is `0` or `false`, streaming is disabled unless `--stream` is
 explicitly provided. When `HOMEDOC_TZ` is set, folder mode uses that timezone
-for the `<YYYYMMDD-HHMMSS>` output name.
+for the `<YYYYMMDD-HHMMSS>` output name. Without `--outfile`, the translated
+subtitle is written as `{basename}.{dst}.{fmt}` inside the resolved output
+directory; relative templates are interpreted within that directory.
 
 ## Examples
 
@@ -47,6 +51,18 @@ setzer --in drama.srt --out ./translated --server http://127.0.0.1:11434 --model
 
 ```bash
 setzer --in talk.vtt --out ./translated --flat
+```
+
+### Custom output format and template
+
+```bash
+setzer --in drama.srt --out ./translated --outfmt vtt --outfile "~/subs/{basename}.{dst}.{fmt}"
+```
+
+### Timestamped template example
+
+```bash
+setzer --in drama.srt --out ./translated --outfile "~/subs/{basename}.{dst}.{fmt}.{ts}"
 ```
 
 ### Batch mode


### PR DESCRIPTION
## Summary
- add `--outfmt` and `--outfile` options with helpers to format transcripts and resolve templated paths
- expose the new output controls in the Tk GUI and show placeholder hints when flat output is enabled
- document the workflow changes and extend tests for the new helpers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68dfa701618c832c9a1583bd1a2571c1